### PR TITLE
Export vars with the expvar package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+templeton

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 var (
 	showVersion        = flag.Bool("version", false, "Print version information")
 	mode               = flag.String("mode", "", "One of 'periodic', 'incremental', or 'full'. Required except for --version.")
+	debugPort          = flag.String("debug-port", "60000", "Listen port for requests to /debug/vars.")
 	cfgPath            = flag.String("config", "", "Path to the configuration file. Required except for --version.")
 	amqpURI            string
 	elasticsearchBase  string
@@ -149,9 +150,9 @@ func doIncrementalMode(es *elasticsearch.Elasticer, d *database.Databaser, clien
 	spin()
 }
 
-func exportVars() {
+func exportVars(port string) {
 	go func() {
-		sock, err := net.Listen("tcp", "0.0.0.0:60000")
+		sock, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%s", port))
 		if err != nil {
 			logcabin.Error.Fatal(err)
 		}
@@ -200,7 +201,7 @@ func main() {
 	}
 	defer client.Close()
 
-	exportVars()
+	exportVars(*debugPort)
 
 	if *mode == "periodic" {
 		doPeriodicMode(es, d, client)


### PR DESCRIPTION
Fires off a goroutine to listen for requests to /debug/vars. The listen port is configurable through the --debug-port option and defaults to 60000. Also adds a .gitignore file.
