### PR TITLE
Add ability to use basic auth with Elasticsearch

### DIFF
--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -23,15 +23,17 @@ var (
 
 // Elasticer is a type used to interact with Elasticsearch
 type Elasticer struct {
-	es      *elastic.Client
-	baseURL string
-	index   string
+	es       *elastic.Client
+	baseURL  string
+	user     string
+	password string
+	index    string
 }
 
 // NewElasticer returns a pointer to an Elasticer instance that has already tested its connection
 // by making a WaitForStatus call to the configured Elasticsearch cluster
-func NewElasticer(elasticsearchBase string, elasticsearchIndex string) (*Elasticer, error) {
-	c, err := elastic.NewClient(elastic.SetURL(elasticsearchBase))
+func NewElasticer(elasticsearchBase string, user string, password string, elasticsearchIndex string) (*Elasticer, error) {
+	c, err := elastic.NewClient(elastic.SetURL(elasticsearchBase), elastic.SetBasicAuth(user, password))
 
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -36,18 +36,20 @@ db:
 `
 
 var (
-	showVersion        = flag.Bool("version", false, "Print version information")
-	mode               = flag.String("mode", "", "One of 'periodic', 'incremental', or 'full'. Required except for --version.")
-	debugPort          = flag.String("debug-port", "60000", "Listen port for requests to /debug/vars.")
-	cfgPath            = flag.String("config", "", "Path to the configuration file. Required except for --version.")
-	amqpURI            string
-	amqpExchangeName   string
-	amqpExchangeType   string
-	amqpQueuePrefix    string
-	elasticsearchBase  string
-	elasticsearchIndex string
-	dbURI              string
-	cfg                *viper.Viper
+	showVersion           = flag.Bool("version", false, "Print version information")
+	mode                  = flag.String("mode", "", "One of 'periodic', 'incremental', or 'full'. Required except for --version.")
+	debugPort             = flag.String("debug-port", "60000", "Listen port for requests to /debug/vars.")
+	cfgPath               = flag.String("config", "", "Path to the configuration file. Required except for --version.")
+	amqpURI               string
+	amqpExchangeName      string
+	amqpExchangeType      string
+	amqpQueuePrefix       string
+	elasticsearchBase     string
+	elasticsearchUser     string
+	elasticsearchPassword string
+	elasticsearchIndex    string
+	dbURI                 string
+	cfg                   *viper.Viper
 )
 
 func init() {
@@ -82,6 +84,8 @@ func initConfig(cfgPath string) {
 
 func loadElasticsearchConfig() {
 	elasticsearchBase = cfg.GetString("elasticsearch.base")
+	elasticsearchUser = cfg.GetString("elasticsearch.user")
+	elasticsearchPassword = cfg.GetString("elasticsearch.password")
 	elasticsearchIndex = cfg.GetString("elasticsearch.index")
 }
 
@@ -257,7 +261,7 @@ func main() {
 
 	initConfig(*cfgPath)
 	loadElasticsearchConfig()
-	es, err := elasticsearch.NewElasticer(elasticsearchBase, elasticsearchIndex)
+	es, err := elasticsearch.NewElasticer(elasticsearchBase, elasticsearchUser, elasticsearchPassword, elasticsearchIndex)
 	if err != nil {
 		logcabin.Error.Fatal(err)
 	}

--- a/templeton.yaml.tmpl
+++ b/templeton.yaml.tmpl
@@ -13,6 +13,8 @@ amqp:
 {{- if tree (printf "%s/elasticsearch" $base) }}
 elasticsearch:
   {{ with $v := (key (printf "%s/elasticsearch/base" $base)) }}base: "{{ $v }}"{{ end }}
+  {{ with $v := (key (printf "%s/elasticsearch/username" $base)) }}user: "{{ $v }}"{{ end }}
+  {{ with $v := (key (printf "%s/elasticsearch/password" $base)) }}password: "{{ $v }}"{{ end }}
   {{ with $v := (key (printf "%s/elasticsearch/data-alias" $base)) }}index: "{{ $v }}"{{ end }}
 {{- end }}
 


### PR DESCRIPTION
Intended behavior is to only use the basic auth when the configuration supplied Elasticsearch username and password are non-empty.